### PR TITLE
new tests and some fixes

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -6,6 +6,11 @@ module Api
     helper_method :authenticate_user
 
     def authenticate_user
+      unless request.headers['Authorization']
+        render json: { errors: ['Not Authenticated'] }, status: :unauthorized
+        return
+      end
+
       token = request.headers['Authorization'].split(' ').last
       begin
         decoded = JWT.decode(token, Rails.application.secret_key_base).first

--- a/config/initializers/couchbase.rb
+++ b/config/initializers/couchbase.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'couchbase'
-include Couchbase
+include Couchbase # rubocop:disable Style/MixinUsage
 require 'dotenv'
 Dotenv.load
 

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -3,7 +3,135 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::Comments', type: :request do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:headers) { { 'Content-Type': 'application/json' } }
+  let(:current_user) { User.new(id: 'current-user-id', username: 'currentuser', email: 'currentuser@example.com', password_digest: BCrypt::Password.create('password'), bio: 'Current user bio', image: 'current_image.png') }
+  let(:article) { Article.new(id: 'article-id', title: 'Test Title', description: 'Test Description', body: 'Test Body', tag_list: ['tag1', 'tag2'], author_id: current_user.id, slug: 'test-title') }
+  let(:comment) { Comment.new(id: 'comment-id', body: 'Test Comment', author_id: current_user.id, article_id: article.id, type: 'comment') }
+  let(:token) { JWT.encode({ user_id: current_user.id }, Rails.application.secret_key_base) }
+  let(:options) do
+    instance_double(Couchbase::Options::Query, positional_parameters: ['article-id'])
+  end
+  let(:query_result) do
+    instance_double(Couchbase::Cluster::QueryResult, rows: [comment.to_hash.merge('_default' => comment.to_hash)])
+  end
+
+  before do
+    mock_couchbase_methods
+
+    allow(Couchbase::Options::Query).to receive(:new).and_return(options)
+    allow(User).to receive(:find).with(current_user.id).and_return(current_user)
+    allow(Article).to receive(:find_by_slug).with(article.slug).and_return(article)
+    allow(JWT).to receive(:decode).and_return([{ 'user_id' => current_user.id }])
+    allow(mock_cluster).to receive(:query).with(
+      "SELECT META().id, * FROM RealWorldRailsBucket.`_default`.`_default` WHERE `type` = 'comment' AND `article_id` = ?", options
+    ).and_return(query_result)
+    allow(mock_collection).to receive(:upsert)
+    allow(mock_collection).to receive(:remove)
+  end
+
+  describe 'GET /api/articles/:slug/comments' do
+    it 'returns all comments for the article' do
+      allow(article).to receive(:comments).and_return([comment])
+
+      get "/api/articles/#{article.slug}/comments", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['comments'].first['body']).to eq('Test Comment')
+    end
+
+    it 'returns an error if the article is not found' do
+      allow(Article).to receive(:find_by_slug).with('unknown-slug').and_return(nil)
+
+      get "/api/articles/unknown-slug/comments", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)['errors']).to include('Article not found')
+    end
+  end
+
+  describe 'POST /api/articles/:slug/comments' do
+    context 'when authenticated' do
+      it 'creates a new comment for the article' do
+        allow(article).to receive(:add_comment).and_return(comment)
+        allow_any_instance_of(Comment).to receive(:save).and_return(true)
+
+        post "/api/articles/#{article.slug}/comments", params: { comment: { body: 'Test Comment' } }.to_json, headers: headers.merge('Authorization': "Bearer #{token}")
+
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)['comment']['body']).to eq('Test Comment')
+      end
+
+      it 'returns an error if the comment cannot be created' do
+        allow(article).to receive(:add_comment).and_return(comment)
+        allow_any_instance_of(Comment).to receive(:save).and_return(false)
+        allow_any_instance_of(Comment).to receive_message_chain(:errors, :full_messages).and_return(['Error message'])
+
+        post "/api/articles/#{article.slug}/comments", params: { comment: { body: 'Test Comment' } }.to_json, headers: headers.merge('Authorization': "Bearer #{token}")
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['errors']).to include('Error message')
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns an error' do
+        post "/api/articles/#{article.slug}/comments", params: { comment: { body: 'Test Comment' } }.to_json, headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['errors']).to include('Not Authenticated')
+      end
+    end
+
+    it 'returns an error if the article is not found' do
+      allow(Article).to receive(:find_by_slug).with('unknown-slug').and_return(nil)
+
+      post "/api/articles/unknown-slug/comments", params: { comment: { body: 'Test Comment' } }.to_json, headers: headers.merge('Authorization': "Bearer #{token}")
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)['errors']).to include('Article not found')
+    end
+  end
+
+  describe 'DELETE /api/articles/:slug/comments/:id' do
+    context 'when authenticated' do
+      it 'deletes the comment' do
+        allow(Comment).to receive(:find).with(comment.id).and_return(comment)
+        allow(comment).to receive(:destroy).and_return(true)
+
+        delete "/api/articles/#{article.slug}/comments/#{comment.id}", headers: headers.merge('Authorization': "Bearer #{token}")
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['message']).to eq('Comment deleted successfully')
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns an error' do
+        delete "/api/articles/#{article.slug}/comments/#{comment.id}", headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['errors']).to include('Not Authenticated')
+      end
+    end
+
+    it 'returns an error if the article is not found' do
+      allow(Article).to receive(:find_by_slug).with('unknown-slug').and_return(nil)
+      allow(comment).to receive(:destroy).and_return(false)
+
+      delete "/api/articles/unknown-slug/comments/#{comment.id}", headers: headers.merge('Authorization': "Bearer #{token}")
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)['errors']).to include('Article not found')
+    end
+
+    it 'returns an error if the comment is not found' do
+      allow(Article).to receive(:find_by_slug).with(article.slug).and_return(article)
+      allow(Comment).to receive(:find).and_return(nil)
+
+      delete "/api/articles/#{article.slug}/comments/unknown-id", headers: headers.merge('Authorization': "Bearer #{token}")
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)['errors']).to include('Comment not found')
+    end
   end
 end

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -3,7 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::Tags', type: :request do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:headers) { { 'Content-Type': 'application/json' } }
+  let(:tag1) { Tag.new(id: 'tag1-id', name: 'tag1', type: 'tag') }
+  let(:tag2) { Tag.new(id: 'tag2-id', name: 'tag2', type: 'tag') }
+
+  before do
+    mock_couchbase_methods
+
+    allow(Tag).to receive(:all).and_return([tag1, tag2])
+  end
+
+  describe 'GET /api/tags' do
+    it 'returns all tags' do
+      get '/api/tags', headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['tags']).to eq(['tag1', 'tag2'])
+    end
   end
 end


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added authentication check for `Authorization` header in `ApplicationController`.
- Improved comment creation and deletion logic in `CommentsController` with better error handling.
- Disabled RuboCop warning for `include Couchbase` in Couchbase initializer.
- Added comprehensive tests for comments API endpoints, including creation, retrieval, deletion, and error handling.
- Added tests for tags API endpoint to ensure retrieval of all tags.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application_controller.rb</strong><dd><code>Add authentication check for `Authorization` header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/api/application_controller.rb
<li>Added authentication check for <code>Authorization</code> header.<br> <li> Render error message if <code>Authorization</code> header is missing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/hummusonrails/realworld-yew/pull/17/files#diff-fb6c46b0bf7ad7b327f1ec510e34dce3e105181711987b45e0c775099714c61c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>comments_controller.rb</strong><dd><code>Improve comment creation and deletion logic with error handling</code></dd></summary>
<hr>

app/controllers/api/comments_controller.rb
<li>Changed comment creation to use <code>Comment.new</code>.<br> <li> Added error handling for missing article and comment.<br> <li> Improved authorization check for comment deletion.<br>


</details>
    

  </td>
  <td><a href="https://github.com/hummusonrails/realworld-yew/pull/17/files#diff-84aa3a268dd1817f7181170934cf51cd39481a030aaa299a7bcb04af47188d44">+16/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>couchbase.rb</strong><dd><code>Disable RuboCop warning for Couchbase inclusion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/initializers/couchbase.rb
- Disabled RuboCop warning for `include Couchbase`.



</details>
    

  </td>
  <td><a href="https://github.com/hummusonrails/realworld-yew/pull/17/files#diff-6b6fc9af6c1937943fb96907cf216fc7f6784e59222e946366b559e317c7461d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comments_spec.rb</strong><dd><code>Add comprehensive tests for comments API endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/requests/api/comments_spec.rb
<li>Added tests for comments API endpoints.<br> <li> Included tests for comment creation, retrieval, and deletion.<br> <li> Added error handling tests for missing article and comment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/hummusonrails/realworld-yew/pull/17/files#diff-720db1dd8d1c209f97e537928736fb3ceda1b90e38df41c2d19c0c910614e92a">+130/-2</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tags_spec.rb</strong><dd><code>Add tests for tags API endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/requests/api/tags_spec.rb
<li>Added tests for tags API endpoint.<br> <li> Included test for retrieving all tags.<br>


</details>
    

  </td>
  <td><a href="https://github.com/hummusonrails/realworld-yew/pull/17/files#diff-10ff0987166404396ab694af91975dcf801cc964c924885f4f813ccb4de0151a">+17/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

